### PR TITLE
Add `pluto eval` to evaluate a top-level let binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
     - run: nix-build
     - run: nix flake check
     - run: nix-shell --command 'cabal run pluto -- run examples/hello.pluto'
+    - run: nix-shell --command 'cabal test'

--- a/README.md
+++ b/README.md
@@ -190,19 +190,21 @@ ghcid -T PlutusCore.Assembler.EntryPoint.main --setup ":set args run examples/he
 To run the HelloWorld example,
 
 ```
-cabal run pluto -- run examples/hello.pluto
+cabal run pluto -- -v run examples/hello.pluto
 ```
+
+(The `-v` option dumps intermediate ASTs)
 
 To evaluate a top-level binding with (optional) arguments. For example, this command evalutes the `greet` function from `hello.pluto` by applying it with the two given arguments.
 
 ```
-cabal run pluto -- eval examples/hello.pluto greet '"Bonjour"' '"Charles"'
+cabal run pluto -- -v eval examples/hello.pluto greet '"Bonjour"' '"Charles"'
 ```
 
 Top-level variables can also be accessed by ignoring the arguments:
 
 ```
-cabal run pluto -- eval examples/hello.pluto defaultGreeting
+cabal run pluto -- -v eval examples/hello.pluto defaultGreeting
 ```
 
 To only assemble the Pluto program into a Plutus bytecode:

--- a/README.md
+++ b/README.md
@@ -179,20 +179,34 @@ Map ::= "{" ( Data "=" Data )* "}"
 
 Run `nix-shell` (or `nix develop`, if you prefer to use the flake and you have Nix 2.4) to drop yourself in the development shell. From here, you may launch your text-editor and get access to IDE support via Haskell Language Server, as well use `cabal` to build and run the project.
 
+For rapid compilation feedback cycle, Ghcid can be run as follows,
+
+```
+ghcid -T PlutusCore.Assembler.EntryPoint.main --setup ":set args run examples/hello.pluto"
+```
+
+### Examples
+
 To run the HelloWorld example,
 
 ```
 cabal run pluto -- run examples/hello.pluto
 ```
 
+To evaluate a top-level binding with (optional) arguments. For example, this command evalutes the `greet` function from `hello.pluto` by applying it with the two given arguments.
+
+```
+cabal run pluto -- eval examples/hello.pluto greet '"Bonjour"' '"Charles"'
+```
+
+Top-level variables can also be accessed by ignoring the arguments:
+
+```
+cabal run pluto -- eval examples/hello.pluto defaultGreeting
+```
+
 To only assemble the Pluto program into a Plutus bytecode:
 
 ```
 cabal run pluto -- assemble examples/hello.pluto
-```
-
-For rapid compilation feedback cycle, Ghcid can be run as follows,
-
-```
-ghcid -T PlutusCore.Assembler.EntryPoint.main --setup ":set args run examples/hello.pluto"
 ```

--- a/examples/hello.pluto
+++ b/examples/hello.pluto
@@ -1,7 +1,8 @@
 -- Hello world
 let 
-  sayHello = (\name -> 
-    let greeting = "Hello"
-    in (greeting +s name))
+  defaultGreeting = "Hello";
+  greet = (\greeting name -> 
+    (greeting +s ", ") +s name
+  )
 in 
-  sayHello "world"
+  greet defaultGreeting "world"

--- a/flake.nix
+++ b/flake.nix
@@ -43,8 +43,6 @@
                 # Non-Haskell shell tools go here
                 shell.buildInputs = with pkgs; [
                   nixpkgs-fmt
-                  cardano-node.outputs.packages.x86_64-linux."cardano-node:exe:cardano-node"
-                  cardano-node.outputs.packages.x86_64-linux."cardano-cli:exe:cardano-cli"
                 ];
               };
           })

--- a/pluto.cabal
+++ b/pluto.cabal
@@ -18,6 +18,7 @@ library
     PlutusCore.Assembler.Parse
     PlutusCore.Assembler.Prelude
     PlutusCore.Assembler.Tokenize
+    PlutusCore.Assembler.Transform
     PlutusCore.Assembler.Types.AST
     PlutusCore.Assembler.Types.Builtin
     PlutusCore.Assembler.Types.Constant

--- a/src/PlutusCore/Assembler/Assemble.hs
+++ b/src/PlutusCore/Assembler/Assemble.hs
@@ -15,18 +15,19 @@ import           PlutusCore.Assembler.Prelude
 import           PlutusCore.Assembler.Tokenize           (tokenize)
 import           PlutusCore.Assembler.Types.AST          (Program)
 import           PlutusCore.Assembler.Types.ErrorMessage (ErrorMessage)
-import           Text.Parsec.Pos                         (SourcePos)
+import           Text.Parsec.Pos                         (SourceName, SourcePos)
 
 
 -- | Either assemble the given code into Plutus bytecode or fail with an error message.
-assemble :: Text -> Either ErrorMessage ByteString
-assemble = fmap (toStrict . serialise) . translate <=< parseProgram
+assemble :: SourceName -> Text -> Either ErrorMessage ByteString
+assemble name = fmap (toStrict . serialise) . translate <=< parseProgram name
 
 
 -- | Translatre the given Pluto code into a Plutus Script
-translate :: Program SourcePos -> Either ErrorMessage Script
+translate :: Show ann => Program ann -> Either ErrorMessage Script
 translate = fmap Script . (desugar . annDeBruijn)
 
-parseProgram :: Text -> Either ErrorMessage (Program SourcePos)
-parseProgram =
-  parse <=< tokenize
+
+parseProgram :: SourceName -> Text -> Either ErrorMessage (Program SourcePos)
+parseProgram name =
+  parse name <=< tokenize name

--- a/src/PlutusCore/Assembler/Desugar.hs
+++ b/src/PlutusCore/Assembler/Desugar.hs
@@ -15,7 +15,6 @@ import           PlutusCore.Default                      (DefaultFun,
                                                           DefaultUni, Some,
                                                           ValueOf)
 import qualified PlutusCore.Default                      as PLC
-import           Text.Parsec.Pos                         (SourcePos)
 import qualified UntypedPlutusCore.Core.Type             as UPLC
 
 import           PlutusCore.Assembler.AnnDeBruijn        (addNameToMap)
@@ -32,13 +31,15 @@ type UnsweetProgram = UPLC.Program DeBruijn DefaultUni DefaultFun ()
 type UnsweetTerm = UPLC.Term DeBruijn DefaultUni DefaultFun ()
 
 
-desugar :: Program (SourcePos, Map Name DeBruijn)
+desugar :: Show ann
+        => Program (ann, Map Name DeBruijn)
         -> Either ErrorMessage UnsweetProgram
 desugar (AST.Program x) =
   UPLC.Program () (PLC.defaultVersion ()) <$> desugarTerm x
 
 
-desugarTerm :: Term (SourcePos, Map Name DeBruijn)
+desugarTerm :: Show ann
+            => Term (ann, Map Name DeBruijn)
             -> Either ErrorMessage UnsweetTerm
 desugarTerm =
   \case
@@ -78,7 +79,7 @@ desugarTerm =
 
 -- We pass in the bindings innermost first instead of the usual outermost
 -- first convention in order to simplify the recursion.
-desugarLet :: [Binding (SourcePos, Map Name DeBruijn)] -> Term (SourcePos, Map Name DeBruijn) -> Either ErrorMessage UnsweetTerm
+desugarLet :: Show ann => [Binding (ann, Map Name DeBruijn)] -> Term (ann, Map Name DeBruijn) -> Either ErrorMessage UnsweetTerm
 desugarLet [] y = desugarTerm y -- allow this case to make the recursion simpler
 desugarLet ( AST.Binding _ _ e : bs ) y =
   UPLC.Apply ()

--- a/src/PlutusCore/Assembler/EntryPoint.hs
+++ b/src/PlutusCore/Assembler/EntryPoint.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 

--- a/src/PlutusCore/Assembler/Evaluate.hs
+++ b/src/PlutusCore/Assembler/Evaluate.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE TypeApplications  #-}
 
-module PlutusCore.Assembler.Evaluate (eval) where
+module PlutusCore.Assembler.Evaluate (eval, Scripts.ScriptError) where
 
 import           Control.Monad.Except
 import           Plutus.V1.Ledger.Scripts                 (Script)

--- a/src/PlutusCore/Assembler/Parse.hs
+++ b/src/PlutusCore/Assembler/Parse.hs
@@ -8,7 +8,8 @@ module PlutusCore.Assembler.Parse ( parse ) where
 import           Data.Either.Extra                       (mapLeft)
 import           Data.Text                               (pack, unpack)
 import qualified PlutusCore.Data                         as Data
-import           Text.Parsec                             (Parsec, SourcePos,
+import           Text.Parsec                             (Parsec, SourceName,
+                                                          SourcePos,
                                                           getPosition, many,
                                                           many1, option, try)
 import           Text.Parsec.Prim                        (token)
@@ -28,9 +29,8 @@ import qualified PlutusCore.Assembler.Types.Token        as Tok
 type Parser = Parsec [(Token, SourcePos)] ()
 
 
-parse :: [(Token, SourcePos)] -> Either ErrorMessage (Program SourcePos)
-parse = mapLeft (ErrorMessage . pack . show) . Prim.parse program "input"
-
+parse :: SourceName -> [(Token, SourcePos)] -> Either ErrorMessage (Program SourcePos)
+parse name = mapLeft (ErrorMessage . pack . show) . Prim.parse program name
 
 consume :: ((Token, SourcePos) -> Maybe a) -> Parser a
 consume = token (unpack . printToken . fst) snd

--- a/src/PlutusCore/Assembler/Prelude.hs
+++ b/src/PlutusCore/Assembler/Prelude.hs
@@ -23,7 +23,7 @@ module PlutusCore.Assembler.Prelude
 
 import           Control.Applicative  (Applicative (pure), liftA2, (<*>), (<|>))
 import           Control.Arrow        (first, second, (***))
-import           Control.Monad        (forM_, guard, mzero, void, (<=<))
+import           Control.Monad        (forM_, guard, mzero, void, when, (<=<))
 import           Control.Monad.Except (MonadError (throwError),
                                        MonadIO (liftIO), runExceptT)
 import           Data.Bifunctor       (bimap)

--- a/src/PlutusCore/Assembler/Prelude.hs
+++ b/src/PlutusCore/Assembler/Prelude.hs
@@ -31,7 +31,7 @@ import           Data.Either          (either)
 import           Data.Either.Extra    (eitherToMaybe)
 import           Data.List            (concat, find, length, unzip)
 import           Data.Map             (Map)
-import           Data.Maybe           (maybe)
+import           Data.Maybe           (mapMaybe, maybe)
 import           Data.Text            (Text)
 import           Prelude              (Bool (False, True), Bounded, Char,
                                        Either (Left, Right), Enum, Eq,

--- a/src/PlutusCore/Assembler/Prelude.hs
+++ b/src/PlutusCore/Assembler/Prelude.hs
@@ -10,6 +10,7 @@ module PlutusCore.Assembler.Prelude
   , module Data.ByteString
   , module Data.Either
   , module Data.Either.Extra
+  , module Data.Foldable
   , module Data.List
   , module Data.Map
   , module Data.Maybe
@@ -29,6 +30,7 @@ import           Data.Bifunctor       (bimap)
 import           Data.ByteString      (ByteString)
 import           Data.Either          (either)
 import           Data.Either.Extra    (eitherToMaybe)
+import           Data.Foldable        (foldl')
 import           Data.List            (concat, find, length, unzip)
 import           Data.Map             (Map)
 import           Data.Maybe           (mapMaybe, maybe)

--- a/src/PlutusCore/Assembler/Prelude.hs
+++ b/src/PlutusCore/Assembler/Prelude.hs
@@ -6,11 +6,13 @@ module PlutusCore.Assembler.Prelude
   , module Control.Arrow
   , module Control.Monad
   , module Control.Monad.Except
+  , module Data.Bifunctor
   , module Data.ByteString
   , module Data.Either
   , module Data.Either.Extra
   , module Data.List
   , module Data.Map
+  , module Data.Maybe
   , module Data.Text
   , module Prelude
   , (<$$>)
@@ -23,11 +25,13 @@ import           Control.Arrow        (first, second, (***))
 import           Control.Monad        (forM_, guard, mzero, void, (<=<))
 import           Control.Monad.Except (MonadError (throwError),
                                        MonadIO (liftIO), runExceptT)
+import           Data.Bifunctor       (bimap)
 import           Data.ByteString      (ByteString)
 import           Data.Either          (either)
 import           Data.Either.Extra    (eitherToMaybe)
-import           Data.List            (concat, length, unzip)
+import           Data.List            (concat, find, length, unzip)
 import           Data.Map             (Map)
+import           Data.Maybe           (maybe)
 import           Data.Text            (Text)
 import           Prelude              (Bool (False, True), Bounded, Char,
                                        Either (Left, Right), Enum, Eq,

--- a/src/PlutusCore/Assembler/Prelude.hs
+++ b/src/PlutusCore/Assembler/Prelude.hs
@@ -5,7 +5,9 @@ module PlutusCore.Assembler.Prelude
   ( module Control.Applicative
   , module Control.Arrow
   , module Control.Monad
+  , module Control.Monad.Except
   , module Data.ByteString
+  , module Data.Either
   , module Data.Either.Extra
   , module Data.List
   , module Data.Map
@@ -16,24 +18,27 @@ module PlutusCore.Assembler.Prelude
   ) where
 
 
-import           Control.Applicative (Applicative (pure), liftA2, (<*>), (<|>))
-import           Control.Arrow       (first, second, (***))
-import           Control.Monad       (forM_, guard, mzero, void, (<=<))
-import           Data.ByteString     (ByteString)
-import           Data.Either.Extra   (eitherToMaybe)
-import           Data.List           (concat, length, unzip)
-import           Data.Map            (Map)
-import           Data.Text           (Text)
-import           Prelude             (Bool (False, True), Bounded, Char,
-                                      Either (Left, Right), Enum, Eq,
-                                      Foldable (foldMap), Functor (fmap), IO,
-                                      Integer, Integral, Maybe (Just, Nothing),
-                                      Monad (return, (>>=)), Monoid (mempty),
-                                      Num ((*), (+), (-)), Ord, Real,
-                                      Show (show), String, all, const, foldl,
-                                      fst, mconcat, negate, reverse, snd, ($),
-                                      (&&), (.), (/=), (<$), (<$>), (<=), (<>),
-                                      (=<<), (==), (>=), (>>), (||))
+import           Control.Applicative  (Applicative (pure), liftA2, (<*>), (<|>))
+import           Control.Arrow        (first, second, (***))
+import           Control.Monad        (forM_, guard, mzero, void, (<=<))
+import           Control.Monad.Except (MonadError (throwError),
+                                       MonadIO (liftIO), runExceptT)
+import           Data.ByteString      (ByteString)
+import           Data.Either          (either)
+import           Data.Either.Extra    (eitherToMaybe)
+import           Data.List            (concat, length, unzip)
+import           Data.Map             (Map)
+import           Data.Text            (Text)
+import           Prelude              (Bool (False, True), Bounded, Char,
+                                       Either (Left, Right), Enum, Eq,
+                                       Foldable (foldMap), Functor (fmap), IO,
+                                       Integer, Integral, Maybe (Just, Nothing),
+                                       Monad (return, (>>=)), Monoid (mempty),
+                                       Num ((*), (+), (-)), Ord, Real,
+                                       Show (show), String, all, const, foldl,
+                                       fst, mconcat, negate, reverse, snd, ($),
+                                       (&&), (.), (/=), (<$), (<$>), (<=), (<>),
+                                       (=<<), (==), (>=), (>>), (||))
 
 
 (<$$>) :: ( Functor f, Functor g ) => (a -> b) -> f (g a) -> f (g b)

--- a/src/PlutusCore/Assembler/Tokenize.hs
+++ b/src/PlutusCore/Assembler/Tokenize.hs
@@ -19,8 +19,8 @@ import           Data.Either.Combinators                 (mapLeft)
 import           Data.Text                               (cons, pack, replace)
 import           Data.Word                               (Word8)
 import           Text.Hex                                (encodeHex)
-import           Text.Parsec                             (SourcePos, choice,
-                                                          eof, many1)
+import           Text.Parsec                             (SourceName, SourcePos,
+                                                          choice, eof, many1)
 import           Text.Parsec.Char                        (anyChar, char, noneOf,
                                                           oneOf, string)
 import           Text.Parsec.Prim                        (getPosition,
@@ -38,8 +38,8 @@ import           PlutusCore.Assembler.Types.Token        (Token (..))
 -- TODO: convert to Parsec and output [(Token, SourcePos)]
 
 
-tokenize :: Text -> Either ErrorMessage [(Token, SourcePos)]
-tokenize = mapLeft (ErrorMessage . pack . show) . parse tokens "input"
+tokenize :: SourceName -> Text -> Either ErrorMessage [(Token, SourcePos)]
+tokenize name = mapLeft (ErrorMessage . pack . show) . parse tokens name
 
 
 tokens :: Parser [(Token, SourcePos)]

--- a/src/PlutusCore/Assembler/Transform.hs
+++ b/src/PlutusCore/Assembler/Transform.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Functions that query and transform the Pluto AST in various ways
+module PlutusCore.Assembler.Transform
+  ( replaceLetBody
+  , queryTopLevelBinding
+  , applyVarWithString
+  ) where
+
+import           PlutusCore.Assembler.Prelude
+import           PlutusCore.Assembler.Types.AST
+
+replaceLetBody :: Term ann -> Program ann -> Either Text (Program ann)
+replaceLetBody newBody = \case
+  Program (Let ann bindings _oldBody) ->
+    pure $ Program (Let ann bindings newBody)
+  _ ->
+    throwError "expected top-level let binding"
+
+queryTopLevelBinding :: Name -> Program ann -> Either Text (Maybe (Term ann))
+queryTopLevelBinding var = \case
+  Program (Let _ann bindings _body) ->
+    pure $ do
+      Binding _ _ term <- find (\(Binding _ name _) -> name == var) bindings
+      pure term
+  _ ->
+    throwError "expected top-level let binding"
+
+applyVarWithString :: Name -> Term () -> Term ()
+applyVarWithString name = Apply
+    ()
+    (Var () name)

--- a/src/PlutusCore/Assembler/Transform.hs
+++ b/src/PlutusCore/Assembler/Transform.hs
@@ -5,44 +5,42 @@
 
 -- | Functions that query and transform the Pluto AST in various ways
 module PlutusCore.Assembler.Transform
-  ( applyToplevelBoundLambdaWith,
+  ( applyToplevelBinding,
   )
 where
 
 import           PlutusCore.Assembler.Prelude
 import           PlutusCore.Assembler.Types.AST
 
--- | Return a new program that applies a bound lambda with the given argument
+-- | Return a new program that applies a bound lambda with the given arguments
 --
--- The lambda must be bound in a top-level Let binding.
-applyToplevelBoundLambdaWith ::
-  -- | Variable name of the bound lambda
+-- The lambda must be bound in a top-level Let binding. When there are no
+-- arguments, the bound variable's value is returned as is.
+applyToplevelBinding ::
+  -- | Variable name of the bound term (usually a lambda)
   Name ->
-  -- | Argument to apply the lambda with
-  Term () ->
+  -- | Arguments to apply the lambda with
+  --
+  -- If there are no arguments, the bound term is returned as is. If there are
+  -- arguments, the bound term must be a lambda.
+  [Term ()] ->
   -- | The program with the let binding.
   --
   -- The Let body of this program will be discarded.
   Program () ->
-  -- | The new program that retains the let bindings, but with a new body that
-  -- applies the lambda.
+  -- | The new program that retains the let bindings, but with a new body
+  -- containing the expression requested.
   Either Text (Program ())
-applyToplevelBoundLambdaWith var arg = \case
+applyToplevelBinding var args = \case
   Program (Let ann bindings _oldBody) ->
     case getBoundLambda var `mapMaybe` bindings of
-      [_lambdaTerm] ->
-        -- TODO: Use lambdaTerm to process nested lambdas, for handling n-arity
-        -- functions with n>1
-        pure $
-          Program $
-            Let ann bindings $
-              Apply () (Var () var) arg
-      _ -> throwError $ "expected a lambda bound with name: " <> getName var
+      [_boundTerm] -> do
+        let newBody = foldl' (Apply ()) (Var () var) args
+        pure $ Program $ Let ann bindings newBody
+      _ -> throwError $ "expected a binding with name: " <> getName var
   _ ->
     throwError "expected top-level let binding"
   where
     getBoundLambda k (Binding _ k' val) = do
       guard $ k == k'
-      case val of
-        (Lambda _ _ term) -> pure term
-        _                 -> Nothing
+      pure val

--- a/src/PlutusCore/Assembler/Transform.hs
+++ b/src/PlutusCore/Assembler/Transform.hs
@@ -33,7 +33,7 @@ applyToplevelBinding ::
   Either Text (Program ())
 applyToplevelBinding var args = \case
   Program (Let ann bindings _oldBody) ->
-    case getBoundLambda var `mapMaybe` bindings of
+    case getBoundTerm var `mapMaybe` bindings of
       [_boundTerm] -> do
         let newBody = foldl' (Apply ()) (Var () var) args
         pure $ Program $ Let ann bindings newBody
@@ -41,6 +41,6 @@ applyToplevelBinding var args = \case
   _ ->
     throwError "expected top-level let binding"
   where
-    getBoundLambda k (Binding _ k' val) = do
+    getBoundTerm k (Binding _ k' val) = do
       guard $ k == k'
       pure val

--- a/test/PlutusCore/Assembler/Spec/ParseSpec.hs
+++ b/test/PlutusCore/Assembler/Spec/ParseSpec.hs
@@ -30,4 +30,4 @@ testParseValidTokenList =
   testProperty "parses a syntactically valid token list" . property $ do
     n <- forAll genRecursionDepth
     (t, tts) <- forAll (genTerm n)
-    (const () <$$> parse ((,fakeSourcePos) <$> tts)) === Right (Program t)
+    (const () <$$> parse "<test>" ((,fakeSourcePos) <$> tts)) === Right (Program t)

--- a/test/PlutusCore/Assembler/Spec/TokenizeSpec.hs
+++ b/test/PlutusCore/Assembler/Spec/TokenizeSpec.hs
@@ -21,7 +21,6 @@ tests =
   , tokenTest
   ]
 
-
 commutesWithConcatByWhitespaceTest :: TestTree
 commutesWithConcatByWhitespaceTest =
   testProperty "commutes with concatenating strings separated by whitespace in case of a successful parse" . property $ do
@@ -31,7 +30,7 @@ commutesWithConcatByWhitespaceTest =
     case (liftA2 (<>) (f t0) (f t1), f (t0 <> w <> t1)) of
       (Just x, Just y) -> x === y
       _                -> return ()
-  where f = fmap (fmap fst) . eitherToMaybe . tokenize
+  where f = fmap (fmap fst) . eitherToMaybe . tokenize "<test>"
 
 
 prependWhitespaceTest :: TestTree
@@ -39,7 +38,7 @@ prependWhitespaceTest =
   testProperty "result is unaffected by prepending whitespace" . property $ do
     t <- forAll genText
     w <- forAll genWhitespace
-    (fst <$$> eitherToMaybe (tokenize t)) === (fst <$$> eitherToMaybe (tokenize (w <> t)))
+    (fst <$$> eitherToMaybe (tokenize "<test>" t)) === (fst <$$> eitherToMaybe (tokenize "<test>" (w <> t)))
 
 
 appendWhitespaceTest :: TestTree
@@ -47,11 +46,11 @@ appendWhitespaceTest =
   testProperty "result is unaffected by appending whitespace" . property $ do
     t <- forAll genText
     w <- forAll genWhitespace
-    (fst <$$> eitherToMaybe (tokenize t)) === (fst <$$> eitherToMaybe (tokenize (w <> t)))
+    (fst <$$> eitherToMaybe (tokenize "<test>" t)) === (fst <$$> eitherToMaybe (tokenize "<test>" (w <> t)))
 
 
 tokenTest :: TestTree
 tokenTest =
   testProperty "tokenizes a single token" . property $ do
     t <- forAll genToken
-    (fst <$$> tokenize (printToken t)) === Right [t]
+    (fst <$$> tokenize "<test>" (printToken t)) === Right [t]


### PR DESCRIPTION
This PR adds an "eval" command to evaluate a top-level binding of the given Pluto program. It supports evaluating variables that bind to either values or lambdas. In the lambda case, the "eval" command accepts an optional list of arguments each of which are parsed as a `Term` and passed to the lambda via recursive `Apply` (see `applyToplevelBinding`).

The goal is to use this (in lieu of a module system) for running Pluto **unit tests** from Haskell.

CLI examples using (the now modified) `hello.pluto`:


```
❯ cat examples/hello.pluto
-- Hello world
let 
  defaultGreeting = "Hello";
  greet = (\greeting name -> 
    (greeting +s ", ") +s name
  )
in 
  greet defaultGreeting "world"

❯ cabal run pluto -- eval examples/hello.pluto greet '"Bonjour"' '"Charles"'
Constant () (Some (ValueOf string "Bonjour, Charles"))

❯ cabal run pluto -- eval examples/hello.pluto defaultGreeting
Constant () (Some (ValueOf string "Hello"))

❯ cabal run pluto -- eval examples/hello.pluto greet defaultGreeting '"Charles"'
Constant () (Some (ValueOf string "Hello, Charles"))
```

Other changes:
- Refactor CLI code
- Disable AST dumps by default, unless `-v` is passed
- Run `cabal test` in CI