### PR TITLE
Fix let bindings being not being able to reference other let bindings

### DIFF
--- a/src/PlutusCore/Assembler/AnnDeBruijn.hs
+++ b/src/PlutusCore/Assembler/AnnDeBruijn.hs
@@ -37,8 +37,8 @@ annTerm m =
     AST.Builtin a x -> AST.Builtin (a, m) x
     AST.Error a -> AST.Error (a, m)
     AST.Let a bs x ->
-      let (bs', m') = annBindings m (letReverse bs)
-      in AST.Let (a, m) (letReverse bs') (annTerm m' x)
+      let (bs', m') = annBindings m bs
+      in AST.Let (a, m) bs' (annTerm m' x)
     AST.IfThenElse a (AST.IfTerm i) (AST.ThenTerm t) (AST.ElseTerm e) ->
       AST.IfThenElse (a, m)
         (AST.IfTerm (annTerm m i))

--- a/src/PlutusCore/Assembler/AnnDeBruijn.hs
+++ b/src/PlutusCore/Assembler/AnnDeBruijn.hs
@@ -60,7 +60,7 @@ annBindings m [] = ( [], m )
 annBindings m ( AST.Binding a x t : bs ) =
   let m' = addNameToMap m x
       (bs', m'') = annBindings m' bs
-  in ( AST.Binding (a, m) x (annTerm m' t)
+  in ( AST.Binding (a, m) x (annTerm m t)
        : bs'
      , m''
      )

--- a/src/PlutusCore/Assembler/Desugar.hs
+++ b/src/PlutusCore/Assembler/Desugar.hs
@@ -60,7 +60,7 @@ desugarTerm =
     AST.Constant _ x -> pure (UPLC.Constant () (desugarConstant x))
     AST.Builtin _ f -> pure (UPLC.Builtin () (desugarBuiltin f))
     AST.Error _ -> pure (UPLC.Error ())
-    AST.Let _ bs x -> desugarLet (letReverse bs) x
+    AST.Let _ bs x -> desugarLet bs x
     AST.IfThenElse _ (AST.IfTerm i) (AST.ThenTerm t) (AST.ElseTerm e) ->
       UPLC.Apply ()
         <$> ( UPLC.Apply ()

--- a/src/PlutusCore/Assembler/Prelude.hs
+++ b/src/PlutusCore/Assembler/Prelude.hs
@@ -12,7 +12,6 @@ module PlutusCore.Assembler.Prelude
   , module Data.Text
   , module Prelude
   , (<$$>)
-  , letReverse
   ) where
 
 
@@ -38,7 +37,3 @@ import           Prelude             (Bool (False, True), Bounded, Char,
 
 (<$$>) :: ( Functor f, Functor g ) => (a -> b) -> f (g a) -> f (g b)
 f <$$> x = fmap (fmap f) x
-
--- this gets a special name so it is clear which parts of the code are effected by the let desugaring reversal
-letReverse :: [a] -> [a]
-letReverse = reverse


### PR DESCRIPTION
Fix let bindings not being able to reference other let bindings (note: they can still only reference bindings that precede them)