### PR TITLE
Enable starting identifiers with _

### DIFF
--- a/src/PlutusCore/Assembler/Haskell.hs
+++ b/src/PlutusCore/Assembler/Haskell.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies      #-}
 
 -- |

--- a/src/PlutusCore/Assembler/Tokenize.hs
+++ b/src/PlutusCore/Assembler/Tokenize.hs
@@ -121,7 +121,7 @@ token =
 
 var :: Parser Token
 var = do
-  begin <- oneOf ['a'..'z']
+  begin <- oneOf (['a'..'z'] <> "_")
   rest  <- many (oneOf (['a'..'z'] <> ['A'..'Z'] <> ['0'..'9'] <> "_"))
   return (Var (cons begin (pack rest)))
 

--- a/test/PlutusCore/Assembler/Spec/Gen.hs
+++ b/test/PlutusCore/Assembler/Spec/Gen.hs
@@ -91,7 +91,7 @@ genToken =
 
 genName :: Gen Text
 genName = do
-  nm <- (<>) <$> Gen.text (Range.singleton 1) (Gen.element ['a'..'z'])
+  nm <- (<>) <$> Gen.text (Range.singleton 1) (Gen.element (['_']<>['a'..'z']))
               <*> Gen.text (Range.linear 0 100)
                     (Gen.element (['a'..'z']<>['A'..'Z']<>['0'..'9']<>['_']))
   return $ case nm of


### PR DESCRIPTION
This is primarily so we can do `\_ -> expr`