### PR TITLE
`pluto run`: accept script arguments as Plutus `Data`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ Note here that:
 - The `-v` option dumps intermediate ASTs. Ignore it, to display only the script out.
 - We pass a bytestring to the script, as a Pluto literal (which represents bytestrings beginning with `0x`). In general any Plutus `Data` value is accepted.
 
+The echo example can be used to view the Plutus `Data` representation of a given Pluto value, for example:
+
+```
+$ cabal run pluto -- run examples/echo.pluto '{ 2 = 43 }'
+Constant () (Some (ValueOf data (Map [(I 2,I 43)])))
+$
+```
+
 #### `eval`
 
 `eval` can be used to evaluate a top-level binding with (optional) arguments that represented as a Pluto expression. For example, this command evalutes the `greet` function from `hello.pluto` by applying it with the two given arguments.

--- a/README.md
+++ b/README.md
@@ -217,15 +217,22 @@ Currently, you must do all of these steps manually, or run the `manual-ci` funct
 
 ### Examples
 
+#### `run`
+
 To run the HelloWorld example,
 
 ```
-cabal run pluto -- -v run examples/hello.pluto
+cabal run pluto -- run examples/hello.pluto 0x$(echo -n "Charles" | od -A n -t x1 | sed 's/ *//g') -v
 ```
 
-(The `-v` option dumps intermediate ASTs)
+Note here that:
 
-To evaluate a top-level binding with (optional) arguments. For example, this command evalutes the `greet` function from `hello.pluto` by applying it with the two given arguments.
+- The `-v` option dumps intermediate ASTs. Ignore it, to display only the script out.
+- We pass a bytestring to the script, as a Pluto literal (which represents bytestrings beginning with `0x`). In general any Plutus `Data` value is accepted.
+
+#### `eval`
+
+`eval` can be used to evaluate a top-level binding with (optional) arguments that represented as a Pluto expression. For example, this command evalutes the `greet` function from `hello.pluto` by applying it with the two given arguments.
 
 ```
 cabal run pluto -- eval examples/hello.pluto greet '"Bonjour"' '"Charles"'
@@ -236,6 +243,10 @@ Top-level variables can also be accessed by ignoring the arguments:
 ```
 cabal run pluto -- eval examples/hello.pluto defaultGreeting
 ```
+
+Note the distinction between `run` and `eval` *in regards to the type of the arguments*.  `run` expects a Plutus `Data` value; `eval` expects a Pluto expression.
+
+#### `assemble`
 
 To only assemble the Pluto program into a Plutus bytecode:
 

--- a/examples/echo.pluto
+++ b/examples/echo.pluto
@@ -1,0 +1,2 @@
+-- Echos the first command line argument
+(\x -> x)

--- a/examples/hello.pluto
+++ b/examples/hello.pluto
@@ -1,8 +1,11 @@
 -- Hello world
 let 
-  defaultGreeting = "Hello";
+  defaultGreeting = 0x48656c6c6f; -- "Hello"
+  sep = 0x2c20; -- ", "
   greet = (\greeting name -> 
-    (greeting +s ", ") +s name
+    (greeting +b sep) +b name
   )
 in 
-  greet defaultGreeting "world"
+  (\nameData -> 
+    greet defaultGreeting (UnBData nameData)
+  )

--- a/examples/hello.pluto
+++ b/examples/hello.pluto
@@ -1,11 +1,11 @@
 -- Hello world
 let 
-  defaultGreeting = 0x48656c6c6f; -- "Hello"
-  sep = 0x2c20; -- ", "
+  defaultGreeting = "Hello";
   greet = (\greeting name -> 
-    (greeting +b sep) +b name
+    (greeting +s ", ") +s name
   )
 in 
+  -- The argument is a Plutus Data value
   (\nameData -> 
-    greet defaultGreeting (UnBData nameData)
+    greet defaultGreeting (DecodeUtf8 (UnBData nameData))
   )

--- a/src/PlutusCore/Assembler/Assemble.hs
+++ b/src/PlutusCore/Assembler/Assemble.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 
-module PlutusCore.Assembler.Assemble (assemble, translate, parseProgram) where
+module PlutusCore.Assembler.Assemble (assemble, translate, parseProgram, parsePlutusData) where
 
 
 import           Codec.Serialise                         (serialise)
@@ -10,11 +10,12 @@ import           Plutus.V1.Ledger.Scripts                (Script (..))
 
 import           PlutusCore.Assembler.AnnDeBruijn        (annDeBruijn)
 import           PlutusCore.Assembler.Desugar            (desugar)
-import           PlutusCore.Assembler.Parse              (parse)
+import           PlutusCore.Assembler.Parse              (parse, parseData)
 import           PlutusCore.Assembler.Prelude
 import           PlutusCore.Assembler.Tokenize           (tokenize)
 import           PlutusCore.Assembler.Types.AST          (Program)
 import           PlutusCore.Assembler.Types.ErrorMessage (ErrorMessage)
+import qualified PlutusCore.Data                         as PLC
 import           Text.Parsec.Pos                         (SourceName, SourcePos)
 
 
@@ -31,3 +32,7 @@ translate = fmap Script . (desugar . annDeBruijn)
 parseProgram :: SourceName -> Text -> Either ErrorMessage (Program SourcePos)
 parseProgram name =
   parse name <=< tokenize name
+
+parsePlutusData :: SourceName -> Text -> Either ErrorMessage PLC.Data
+parsePlutusData name =
+  parseData name <=< tokenize name

--- a/src/PlutusCore/Assembler/Desugar.hs
+++ b/src/PlutusCore/Assembler/Desugar.hs
@@ -169,6 +169,7 @@ desugarBuiltin =
     UnConstrData            -> PLC.UnConstrData
     UnMapData               -> PLC.UnMapData
     UnBData                 -> PLC.UnBData
+    UnIData                 -> PLC.UnIData
     EqualsData              -> PLC.EqualsData
     MkPairData              -> PLC.MkPairData
     MkNilData               -> PLC.MkNilData

--- a/src/PlutusCore/Assembler/EntryPoint.hs
+++ b/src/PlutusCore/Assembler/EntryPoint.hs
@@ -18,10 +18,8 @@ import           System.IO                               (FilePath, getContents,
                                                           print, writeFile)
 import           Text.Hex                                (encodeHex)
 
-import qualified Codec.Serialise                         as Serialise
-import qualified Data.ByteString.Lazy                    as BS
+import qualified Data.Bifunctor                          as Bifunctor
 import qualified Data.Text                               as T
-import           Data.Text.Encoding                      (encodeUtf8)
 import qualified Plutus.V1.Ledger.Scripts                as Scripts
 import           PlutusCore.Assembler.App
 import qualified PlutusCore.Assembler.Assemble           as Assemble
@@ -91,8 +89,8 @@ command = do
         bimap (T.unpack . getErrorMessage) (void . AST.unProgram) $ Assemble.parseProgram "<cli-arg>" s
     dataReader :: O.ReadM PLC.Data
     dataReader =
-      O.eitherReader $ \(Serialise.deserialise . BS.fromStrict . encodeUtf8 . T.pack -> x) ->
-        pure x
+      O.eitherReader $ \(Assemble.parsePlutusData "<cli-arg>" . T.pack -> x) ->
+        Bifunctor.first show x
 
 
 commandInfo :: O.ParserInfo (Command, Verbose)

--- a/src/PlutusCore/Assembler/Parse.hs
+++ b/src/PlutusCore/Assembler/Parse.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 
-module PlutusCore.Assembler.Parse ( parse ) where
+module PlutusCore.Assembler.Parse ( parse, parseData ) where
 
 
 import           Data.Either.Extra                       (mapLeft)
@@ -30,7 +30,13 @@ type Parser = Parsec [(Token, SourcePos)] ()
 
 
 parse :: SourceName -> [(Token, SourcePos)] -> Either ErrorMessage (Program SourcePos)
-parse name = mapLeft (ErrorMessage . pack . show) . Prim.parse program name
+parse = parse' program
+
+parseData :: SourceName -> [(Token, SourcePos)] -> Either ErrorMessage Data
+parseData = parse' dataLiteral
+
+parse' :: Parser a -> SourceName -> [(Token, SourcePos)] -> Either ErrorMessage a
+parse' p name = mapLeft (ErrorMessage . pack . show) . Prim.parse p name
 
 consume :: ((Token, SourcePos) -> Maybe a) -> Parser a
 consume = token (unpack . printToken . fst) snd

--- a/src/PlutusCore/Assembler/Tokenize.hs
+++ b/src/PlutusCore/Assembler/Tokenize.hs
@@ -368,6 +368,7 @@ builtin =
   , UnConstrData <$ string "UnConstrData"
   , UnMapData <$ string "UnMapData"
   , UnBData <$ string "UnBData"
+  , UnIData <$ string "UnIData"
   , EqualsData <$ string "EqualsData"
   , MkPairData <$ string "MkPairData"
   , MkNilData <$ string "MkNilData"

--- a/src/PlutusCore/Assembler/Types/Builtin.hs
+++ b/src/PlutusCore/Assembler/Types/Builtin.hs
@@ -55,6 +55,7 @@ data Builtin =
   | UnConstrData
   | UnMapData
   | UnBData
+  | UnIData
   | EqualsData
   | MkPairData
   | MkNilData


### PR DESCRIPTION
Make the `run` command take from CLI and pass a list of arguments to a Pluto script when evaluating it, with each argument represented as a Plutus `Data` type but parsed as a Pluto value.

The `hello.pluto` script is modified to evaluate to a lambda taking a ByteString value as its argument. 

```haskell
  (\nameData -> 
    greet defaultGreeting (DecodeUtf8 (UnBData nameData))
  )
```

This argument, `nameData`, corresponds to the `B` constructor in Plutus, but we write it out as a Pluto value:

```
cabal run pluto -- run examples/hello.pluto \
   0x$(echo -n "Charles" | od -A n -t x1 | sed 's/ *//g')
```

(In Pluto, ByteStrings are parsed as `0x<hex-value>`, which is what the above od/sed command produces).

---

This PR can be merged as is. The next thing I want to figure out is a way to pass sum types (and map, etc.) _and_ use them from the .pluto script. @ursi used hand-written Scott encoding for sum types; if we are to pass that `Datum` as an argument in `run` (using this PR) - then I think we will have to figure out a way to 'map' that value to its Scott-encoding so that its (inner) values can be used from the Plutus script.

Once we have that, we can take a serialized dump of some `ScriptContext` - and run a real validator script to see how it works.
