### PR TITLE
Working with Plutus Data (lists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,3 +281,28 @@ $(FFI.bind 'hello
 ```
 
 The above exposes the two top-level bindings from the hello.pluto program, using the given type declaration. 
+
+### Working with Plutus `Data`
+
+The `data` keyword can be used to create lists, maps, and sigma types. For example:
+
+```lisp
+let 
+  x = data [1, 2, 3]
+in 
+  x
+```
+
+Plutus provides a number of builtins to work with `Data`. For operating on lists, we have:
+
+- `UnListData :: Data -> [Data]` (fails if the Data is not a list)
+- `HeadList :: [a] -> a` (fails if list is empty)
+- `TailList :: [a] -> [a]`
+- `ChooseList` can be used to "case" on lists
+
+Higher-level operations on lists can be written in Pluto itself. For example, `fibonacci.pluto` and `sum.pluto` defines "fold".
+
+```
+$ cabal run pluto -- run examples/fibonacci.pluto 5
+Constant () (Some (ValueOf data (List [I 8,I 5,I 3,I 2,I 1,I 1,I 0])))
+```

--- a/examples/fibonacci.pluto
+++ b/examples/fibonacci.pluto
@@ -1,0 +1,41 @@
+let 
+  fix = (\f -> (\x -> f (\v -> x x v)) (\x -> f (\v -> x x v)));
+  fold = (\f ->
+    fix 
+      (\fold x0 xs ->
+        ! ! ChooseList 
+          xs 
+          (\_ -> x0)
+          (\_ -> fold (f x0 (! HeadList xs)) (! TailList xs))
+          ()
+      )
+    );
+
+  -- | range :: Int -> Int -> [Int]
+  -- 
+  -- range 1 5 => [1, 2, 3, 4, 5]
+  range =
+    fix 
+      (\range acc a b ->
+        if b `LessThanEqualsInteger` a
+            then acc 
+            else ! MkCons (IData a) (range acc (a +i 1) b));
+
+  -- | fibonacciSeries :: Int -> [Int]
+  --
+  -- fibonacciSeries 10 => [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55] (in reverse)
+  fibonacciSeries_ = (\n ->
+    fold 
+      (\acc _ -> 
+          let b = ! HeadList acc;
+              a = ! HeadList (! TailList acc)
+          in ! MkCons (IData (UnIData a +i UnIData b)) acc)
+      (UnListData (data [1, 0]))
+      (range (UnListData (data [])) 1 n)
+  );
+
+  fibonacciSeries = (\cnt ->
+    ListData (fibonacciSeries_ (UnIData cnt)))
+in
+  fibonacciSeries
+  

--- a/examples/fibonacci.pluto
+++ b/examples/fibonacci.pluto
@@ -31,11 +31,11 @@ let
               a = ! HeadList (! TailList acc)
           in ! MkCons (IData (UnIData a +i UnIData b)) acc)
       (UnListData (data [1, 0]))
-      (range (UnListData (data [])) 1 n)
+      (range (UnListData (data [])) 0 n)
   );
 
   fibonacciSeries = (\cnt ->
     ListData (fibonacciSeries_ (UnIData cnt)))
 in
   fibonacciSeries
-  
+ 

--- a/examples/sum.pluto
+++ b/examples/sum.pluto
@@ -3,20 +3,19 @@
 let 
   fix = (\f -> (\x -> f (\v -> x x v)) (\x -> f (\v -> x x v)));
   compose = (\f g x -> f (g x));
-  -- TODO: This is work in progress (see TODO inside)
   map = 
     fix 
       (\map f xs ->
         ! ! ChooseList 
           xs 
-          (\_ -> NullList) -- TODO
+          (\_ -> NullList) -- TODO: This doesn't work
           (\_ -> 
             ! MkCons 
               (f (! HeadList xs))
               (map f (! TailList xs)))
           ()
       );
-  -- TODO: Avoid passing 'f', via implementing `map` above.
+  -- FIXME: Avoid passing 'f', via implementing `map` above.
   sumList = (\f ->
     fix 
       (\sumList xs ->
@@ -26,8 +25,9 @@ let
           (\_ -> (f (! HeadList xs)) +i (sumList (! TailList xs))) 
           ()
         ) 
-  )
+  );
+  sumIntList = sumList UnIData `compose` UnListData
 in 
   (\nums -> 
-    sumList UnIData (UnListData nums)
-)
+    sumIntList nums
+  )

--- a/examples/sum.pluto
+++ b/examples/sum.pluto
@@ -3,19 +3,8 @@
 let 
   fix = (\f -> (\x -> f (\v -> x x v)) (\x -> f (\v -> x x v)));
   compose = (\f g x -> f (g x));
-  map = 
-    fix 
-      (\map f xs ->
-        ! ! ChooseList 
-          xs 
-          (\_ -> NullList) -- TODO: This doesn't work
-          (\_ -> 
-            ! MkCons 
-              (f (! HeadList xs))
-              (map f (! TailList xs)))
-          ()
-      );
-  -- FIXME: Avoid passing 'f', via implementing `map` above.
+  -- TODO: Write a `map` to avoid this 'f'. 
+  -- It will require us to figure out how to use NullList properly.
   sumList = (\f ->
     fix 
       (\sumList xs ->

--- a/examples/sum.pluto
+++ b/examples/sum.pluto
@@ -1,0 +1,33 @@
+-- Adds numbers from command line
+-- The argument is a Plutus Data value
+let 
+  fix = (\f -> (\x -> f (\v -> x x v)) (\x -> f (\v -> x x v)));
+  compose = (\f g x -> f (g x));
+  -- TODO: This is work in progress (see TODO inside)
+  map = 
+    fix 
+      (\map f xs ->
+        ! ! ChooseList 
+          xs 
+          (\_ -> NullList) -- TODO
+          (\_ -> 
+            ! MkCons 
+              (f (! HeadList xs))
+              (map f (! TailList xs)))
+          ()
+      );
+  -- TODO: Avoid passing 'f', via implementing `map` above.
+  sumList = (\f ->
+    fix 
+      (\sumList xs ->
+        ! ! ChooseList 
+          xs 
+          (\_ -> 0) 
+          (\_ -> (f (! HeadList xs)) +i (sumList (! TailList xs))) 
+          ()
+        ) 
+  )
+in 
+  (\nums -> 
+    sumList UnIData (UnListData nums)
+)

--- a/examples/sum.pluto
+++ b/examples/sum.pluto
@@ -3,20 +3,22 @@
 let 
   fix = (\f -> (\x -> f (\v -> x x v)) (\x -> f (\v -> x x v)));
   compose = (\f g x -> f (g x));
-  -- TODO: Write a `map` to avoid this 'f'. 
-  -- It will require us to figure out how to use NullList properly.
-  sumList = (\f ->
+
+  fold = (\f ->
     fix 
-      (\sumList xs ->
+      (\fold x0 xs ->
         ! ! ChooseList 
           xs 
-          (\_ -> 0) 
-          (\_ -> (f (! HeadList xs)) +i (sumList (! TailList xs))) 
+          (\_ -> x0)
+          (\_ -> fold (f x0 (! HeadList xs)) (! TailList xs))
           ()
-        ) 
-  );
-  sumIntList = sumList UnIData `compose` UnListData
+      )
+    );
+
+  sumList_ = 
+    fold 
+      (\x y -> x +i (UnIData y) )
+      0;
+  sumIntList = sumList_ `compose` UnListData
 in 
-  (\nums -> 
-    sumIntList nums
-  )
+  (\nums -> sumIntList nums)

--- a/src/PlutusCore/Assembler/Desugar.hs
+++ b/src/PlutusCore/Assembler/Desugar.hs
@@ -168,6 +168,7 @@ desugarBuiltin =
     BData                   -> PLC.BData
     UnConstrData            -> PLC.UnConstrData
     UnMapData               -> PLC.UnMapData
+    UnListData              -> PLC.UnListData
     UnBData                 -> PLC.UnBData
     UnIData                 -> PLC.UnIData
     EqualsData              -> PLC.EqualsData

--- a/src/PlutusCore/Assembler/Evaluate.hs
+++ b/src/PlutusCore/Assembler/Evaluate.hs
@@ -47,7 +47,7 @@ evalToplevelBindingToHaskellValueMust name args prog =
         error $ show err
       Right t ->
         case H.fromUPLC t of
-          Nothing -> error "processResult: failed to convert term"
+          Nothing -> error $ "processResult: failed to convert term: " <> show t
           Just x  -> x
 
 evalToplevelBinding :: AST.Name -> [AST.Term ()] -> AST.Program () -> Either Error (Term Name DefaultUni DefaultFun ())

--- a/src/PlutusCore/Assembler/FFI.hs
+++ b/src/PlutusCore/Assembler/FFI.hs
@@ -82,8 +82,13 @@ simpleD name type_ bodyF = do
   where
     lambdaArgsFromType :: Type -> Q [Name]
     lambdaArgsFromType = \case
+      -- a
       ConT _ -> do
         pure []
+      -- [a]
+      AppT ListT _ -> do
+        pure []
+      -- a -> b
       AppT (AppT ArrowT _) rest -> do
         n <- newName "_arg"
         (n :) <$> lambdaArgsFromType rest

--- a/src/PlutusCore/Assembler/FFI.hs
+++ b/src/PlutusCore/Assembler/FFI.hs
@@ -84,11 +84,11 @@ simpleD name type_ bodyF = do
     lambdaArgsFromType = \case
       ConT _ -> do
         pure []
-      AppT (AppT ArrowT (ConT _)) rest -> do
+      AppT (AppT ArrowT _) rest -> do
         n <- newName "_arg"
         (n :) <$> lambdaArgsFromType rest
-      _ ->
-        fail "simpleD: unexpected type"
+      t ->
+        fail $ "simpleD: unexpected type " <> show t
 
 -- | Like `liftData` but `Data.Text`-friendly.
 --

--- a/src/PlutusCore/Assembler/Haskell.hs
+++ b/src/PlutusCore/Assembler/Haskell.hs
@@ -15,6 +15,7 @@ import qualified Data.Text                      as T
 import qualified PlutusCore                     as PLC
 import           PlutusCore.Assembler.Prelude
 import           PlutusCore.Assembler.Types.AST
+import qualified PlutusTx.IsData.Class          as Plutus
 import qualified UntypedPlutusCore              as UPLC
 
 -- | Class of all Haskell values that can be represented in Pluto
@@ -29,10 +30,24 @@ instance ToPluto Text where
   toPluto s =
     Constant () $ T () s
 
-instance ToPluto [Char] where
+-- Overlaps the [a] instance below, because strings are represented internally,
+-- as opposed to being opaque in a `Data`.
+instance {-# OVERLAPPING #-} ToPluto [Char] where
   toPluto s =
     Constant () $ T () $ T.pack s
 
+instance ToPluto Integer where
+  toPluto x =
+    Constant () $ I () x
+
+instance {-# OVERLAPPABLE #-} Plutus.ToData a => ToPluto [a] where
+  toPluto xs =
+    Constant () $ D () $ Plutus.toData xs
+
+instance FromUPLC Integer where
+  fromUPLC = \case
+    (UPLC.Constant () (PLC.Some (PLC.ValueOf PLC.DefaultUniInteger x))) -> pure x
+    _                                                                  -> Nothing
 instance FromUPLC Text where
   fromUPLC = \case
     (UPLC.Constant () (PLC.Some (PLC.ValueOf PLC.DefaultUniString x))) -> pure x

--- a/src/PlutusCore/Assembler/Haskell.hs
+++ b/src/PlutusCore/Assembler/Haskell.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- |
 module PlutusCore.Assembler.Haskell
@@ -30,8 +31,8 @@ instance ToPluto Text where
   toPluto s =
     Constant () $ T () s
 
--- Overlaps the [a] instance below, because strings are represented internally,
--- as opposed to being opaque in a `Data`.
+-- Overlaps the ToData  instance below, because strings are represented
+-- internally, as opposed to being opaque in a `Data`.
 instance {-# OVERLAPPING #-} ToPluto [Char] where
   toPluto s =
     Constant () $ T () $ T.pack s
@@ -40,7 +41,7 @@ instance ToPluto Integer where
   toPluto x =
     Constant () $ I () x
 
-instance {-# OVERLAPPABLE #-} Plutus.ToData a => ToPluto [a] where
+instance {-# OVERLAPPABLE #-} Plutus.ToData a => ToPluto a where
   toPluto xs =
     Constant () $ D () $ Plutus.toData xs
 
@@ -55,3 +56,9 @@ instance FromUPLC Text where
 
 instance FromUPLC String where
   fromUPLC = fmap T.unpack . fromUPLC
+
+instance FromUPLC Data where
+  fromUPLC = \case
+    (UPLC.Constant () (PLC.Some (PLC.ValueOf PLC.DefaultUniData x))) -> pure x
+    _                                                                -> Nothing
+

--- a/src/PlutusCore/Assembler/Tokenize.hs
+++ b/src/PlutusCore/Assembler/Tokenize.hs
@@ -367,6 +367,7 @@ builtin =
   , BData <$ string "BData"
   , UnConstrData <$ string "UnConstrData"
   , UnMapData <$ string "UnMapData"
+  , UnListData <$ string "UnListData"
   , UnBData <$ string "UnBData"
   , UnIData <$ string "UnIData"
   , EqualsData <$ string "EqualsData"

--- a/src/PlutusCore/Assembler/Types/Builtin.hs
+++ b/src/PlutusCore/Assembler/Types/Builtin.hs
@@ -54,6 +54,7 @@ data Builtin =
   | BData
   | UnConstrData
   | UnMapData
+  | UnListData
   | UnBData
   | UnIData
   | EqualsData

--- a/test/PlutusCore/Assembler/Spec/ExamplesSpec.hs
+++ b/test/PlutusCore/Assembler/Spec/ExamplesSpec.hs
@@ -15,7 +15,11 @@ import qualified PlutusCore.Assembler.FFI          as FFI
 import           PlutusCore.Assembler.Prelude
 import           PlutusCore.Assembler.Spec.Prelude
 import qualified PlutusCore.Assembler.Types.AST    as AST
-import           Prelude                           (Foldable (sum), toInteger)
+import qualified PlutusCore.Data                   as PLC
+import           PlutusTx                          (toBuiltinData)
+import           PlutusTx.Builtins                 (BuiltinData)
+import           Prelude                           (Foldable (sum), head, tail,
+                                                    toInteger)
 
 -- FFIs must be declared before tests
 hello :: AST.Program ()
@@ -31,12 +35,18 @@ sumProg = $(FFI.load "examples/sum.pluto")
 $(FFI.bind 'sumProg
   "sumIntList" [t|[Integer] -> Integer|])
 
+fibProg :: AST.Program ()
+fibProg = $(FFI.load "examples/fibonacci.pluto")
+$(FFI.bind 'fibProg
+  "fibonacciSeries" [t|BuiltinData -> PLC.Data|])
+
 tests :: TestTree
 tests =
   testGroup
     "examples"
     [ helloTest
     , sumTest
+    , fibTest
     ]
 
 helloTest :: TestTree
@@ -62,4 +72,14 @@ sumTest =
     [ testProperty "can sum integers" . property $ do
         xs <- fmap (fmap toInteger) $ forAll $ Gen.list (Range.linear 0 15) (Gen.int (Range.linear 0 100))
         sumIntList xs === sum xs
+    ]
+
+fibTest :: TestTree
+fibTest =
+  testGroup
+    "fibonacci.pluto"
+    [ testProperty "fib works" . property $ do
+        n <- fmap toInteger $ forAll $ Gen.int (Range.linear 0 100)
+        let ans = foldl' (\acc _ -> (head acc + head (tail acc)) : acc) [1, 0] [1..(n-1)]
+        fibonacciSeries (toBuiltinData n) === PLC.List (PLC.I <$> ans)
     ]

--- a/test/PlutusCore/Assembler/Spec/ExamplesSpec.hs
+++ b/test/PlutusCore/Assembler/Spec/ExamplesSpec.hs
@@ -80,6 +80,6 @@ fibTest =
     "fibonacci.pluto"
     [ testProperty "fib works" . property $ do
         n <- fmap toInteger $ forAll $ Gen.int (Range.linear 0 100)
-        let ans = foldl' (\acc _ -> (head acc + head (tail acc)) : acc) [1, 0] [1..(n-1)]
+        let ans = foldl' (\acc _ -> (head acc + head (tail acc)) : acc) [1, 0] [0..(n-1)]
         fibonacciSeries (toBuiltinData n) === PLC.List (PLC.I <$> ans)
     ]


### PR DESCRIPTION
Adds a couple of examples, modifying Pluto assembler along the way, as well as uses them from Haskell - effectively demonstrating how to deal with Plutus `Data` - specifically its `List` constructor. Explanation added to README. Incidentally resolves #21 

Natural next step from here would be to look at (manually) decoding `Constr` for using ScriptContext in Pluto.
