### PR TITLE
Update Cachix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [Herc badge]: https://img.shields.io/badge/ci--by--hercules-green.svg
 [Herc link]: https://hercules-ci.com/github/Plutonomicon/pluto 
 [Cachix badge]: https://img.shields.io/badge/cachix-plutonomicon--pluto-blue.svg
-[Cachix link]: https://plutonomicon-pluto.cachix.org
+[Cachix link]: https://public-plutonomicon.cachix.org
 [Built with Nix badge]: https://builtwithnix.org/badge.svg
 [Built with Nix link]: https://builtwithnix.org
 


### PR DESCRIPTION
I've configured a new powerful CI agent running a Ryzen 3900x, it is now pushing to `public-plutonomicon.cachix.org`. This updates the Cachix information in the README.md.